### PR TITLE
Update gatling_script.scala

### DIFF
--- a/gatling/gatling_script.scala
+++ b/gatling/gatling_script.scala
@@ -284,13 +284,14 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 			endTimePackage(sensorIndex)=Calendar.getInstance().getTimeInMillis()
 			//duration that took the package to send all the messages
 			duration(sensorIndex)=endTimePackage(sensorIndex)-startTimePackage(sensorIndex)
-			session
+			//Put parameters in session for next synthesis request
+			session.set("paramDuration", ""+(duration(sensorIndex)/1000).toInt).set("paramTimestamp", java.net.URLEncoder.encode(formatter.format(startTimePackage(sensorIndex)), "utf-8"))
 			})
 			//call and get the synthesis corresponding to the duration and timestamp
 			.exec(http(synthesisResultsCheck(sensorIndex))
-					.get("http://192.168.1.1/messages/synthesis?timestamp="+
-					java.net.URLEncoder.encode(formatter.format(startTimePackage(sensorIndex)), "utf-8")+
-					"&duration="+(duration(sensorIndex)/1000).toInt)
+					.get("http://192.168.1.1/messages/synthesis")
+					.queryParam("duration", "${paramDuration}")
+					.queryParam("timestamp", "${paramTimestamp}")
   					.check(jsonPath("$..*").findAll.saveAs(SynthesisSensorNum(sensorIndex)))
 					.headers(header)
 					.check(status.is(200)))
@@ -395,9 +396,10 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 		var resultatValid=true
 		
 		//this is the url of the synthesis get method that sends a synthesis object containing 10 sensor types results
-  		val urlSyhtesis =	"http://192.168.1.1/messages/synthesis?timestamp="
-  						+java.net.URLEncoder.encode(formatter.format(simulationStartTime), "utf-8")
-  						+"&duration="+((timeOfSimulation/1000000000)+1).toInt
+  		val urlSyhtesis = "http://192.168.1.1/messages/synthesis?timestamp="
+  						.concat(java.net.URLEncoder.encode(formatter.format(simulationStartTime), "utf-8"))
+  						.concat("&duration=")
+  						.concat(""+((timeOfSimulation/1000000000)+1).toInt)
   						
   		val result = scala.io.Source.fromURL(urlSyhtesis)
 


### PR DESCRIPTION
Je ne suis pas un spécialiste de scala/gatling: Ce que je push fonctionne sur mon poste mais je ne sais pas si c'est syntaxiquement/conceptuellement correct.

1 - Passage des paramètres des rqt de synthèse intermédiaire par la session + queryParam:
La concaténation avec le "+"ne compile pas sur mon poste et en le corrigeant (passage par concat()), je reçois toujours 01/01/1970 (soit 0...) pour le timestmap et 0 pour la duration.
En debugant, je vois qu'en envoyant la duration en sec, on perd pas mal de précisons (1450ms => 1sec)...je me demande si il ne faut pas l''envoyer en ms.

2 - Passage de "+" à concat() pour la rqt de synthèse globale:
Même problème que le 1, ça ne compile pas sur mon poste sans ça
