### PR TITLE
System.nanoTime() n'est pas relatif à la date 0

### DIFF
--- a/gatling/gatling_script.scala
+++ b/gatling/gatling_script.scala
@@ -61,6 +61,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 	
 	//the simulation start in nano seconds
 	var simulationStartTime=0.0
+	var simulationStartTimeMs=0.0
 	//the simulation end in nano seconds
 	var simulationEndTime=0.0
 	//start time for sending a package by sensor type
@@ -199,7 +200,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
   	*/
 	before {
     		println("la simulation est sur le point de commencer...")
-    		
+    		simulationStartTimeMs=Calendar.getInstance().getTimeInMillis()
     		simulationStartTime=System.nanoTime()		
   	}
 
@@ -396,7 +397,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 		
 		//this is the url of the synthesis get method that sends a synthesis object containing 10 sensor types results
   		val urlSyhtesis =	"http://192.168.1.1/messages/synthesis?timestamp="
-  						+java.net.URLEncoder.encode(formatter.format(simulationStartTime), "utf-8")
+  						+java.net.URLEncoder.encode(formatter.format(simulationStartTimeMs), "utf-8")
   						+"&duration="+((timeOfSimulation/1000000000)+1).toInt
   						
   		val result = scala.io.Source.fromURL(urlSyhtesis)


### PR DESCRIPTION
System.nanoTime() ne retourne pas le nombre de ns depuis une date fixe mais depuis une date arbitraire donc on peut l'utiliser pour calculer des temps d’exécution par défférence mais pas pour calculer des dates.
J'enregistre donc le temps de début de simulation en ms (depuis la date 01/01/1970) pour l'exploiter pour la rqt de synthèse à la fin.
